### PR TITLE
Allow upgrade of devices that come online only periodically

### DIFF
--- a/bin/hodmin
+++ b/bin/hodmin
@@ -67,6 +67,7 @@ cmd_opts = case cmd
                opt :fw_name, 'Select firmware-file by firmware-name', type: String
                opt :checksum, 'Select ONE firmware-files by firmware-checksum', type: String
                opt :upgrade, 'Select newest firmware-file by firmware-name of Homie-device', type: TrueClass
+               opt :offline, 'Upgrade offline devices (will wait till the device comes online)', type: TrueClass
                opt :auto, 'Upgrade in batch mode (do not ask for updating a device'\
                         + ' (be carefull using this option)', type: TrueClass, default: false
              end

--- a/hodmin.gemspec
+++ b/hodmin.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-cursor', '>= 0.4.0'
   spec.add_dependency 'tty-table', '>= 0.7.0'
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/hodmin/hodmin_push_config.rb
+++ b/lib/hodmin/hodmin_push_config.rb
@@ -33,7 +33,8 @@ def hodmin_push_config(gopts, copts)
   my_devs.each do |up_dev|
     copts = get_config_from_option(conf_new)
     puts "Device #{up_dev.mac} is #{up_dev.online_status}"
-    next unless up_dev.online?
+    # Allow updating devices that come online only periodically!
+    # next unless up_dev.online?
     print 'Start updating? <Yn>:'
     answer = STDIN.gets.chomp.downcase
     next unless up_dev.online && 'y' == answer

--- a/lib/hodmin/hodmin_push_firmware.rb
+++ b/lib/hodmin/hodmin_push_firmware.rb
@@ -3,6 +3,7 @@ def hodmin_push_firmware(gopts, copts)
   fw_checksum = copts[:checksum] || ''
   fw_name = copts[:fw_name] || ''
   batchmode = copts[:auto] || false
+  offlinemode = copts[:offline] || false
   mac = gopts[:mac] || ''
   hd_upgrade = gopts[:upgradable_given] && gopts[:upgradable]
   fw_upgrade = copts[:upgrade_given] && copts[:upgrade]
@@ -49,7 +50,7 @@ def hodmin_push_firmware(gopts, copts)
     next if hd_upgrade && !up_dev.upgradable
     my_fw = my_fws.select { |f| f.fw_name == up_dev.fw_name }.sort_by(&:fw_version).last if hd_upgrade
     puts "Device #{up_dev.mac} is #{up_dev.online_status}. (installed FW-Checksum: #{up_dev.fw_checksum})"
-    next unless up_dev.online? && up_dev.fw_checksum != my_fw.checksum
+    next unless (up_dev.online? || offlinemode) && up_dev.fw_checksum != my_fw.checksum
     if batchmode
       answer = 'y'
     else
@@ -57,6 +58,6 @@ def hodmin_push_firmware(gopts, copts)
       answer = STDIN.gets.chomp.downcase
     end
     Log.log.info "Dev. #{up_dev.mac} (running #{up_dev.fw_version}) upgrading to #{my_fw.fw_version}"
-    up_dev.push_firmware_to_dev(my_fw) if 'y' == answer
+    up_dev.push_firmware_to_dev(my_fw, offlinemode) if 'y' == answer
   end
 end


### PR DESCRIPTION
Added an "offline" upgrade mode. My battery-powered devices come online
only for a few seconds every 10 minutes. When in "offline" upgrade mode,
hodmin will publish the firmware checksum with the retain flag on, and
then will wait for the device to come online.

When the device comes online, it will receive the retained message and
start OTA update immediately. The retained firmware checksum is cleared
as soon as the device starts the upgrade process, to prevent OTA loops
etc.